### PR TITLE
fix: disallow adding duplicate items, open existing in edit mode (closes #68)

### DIFF
--- a/src/MediaTracker.jsx
+++ b/src/MediaTracker.jsx
@@ -57,6 +57,7 @@ const exportMovies = (items) => {
 const MediaTracker = () => {
   // Modal states
   const [selectedItem, setSelectedItem] = useState(null);
+  const [openInEditMode, setOpenInEditMode] = useState(false);
   const [isAdding, setIsAdding] = useState(false);
   const [isSearching, setIsSearching] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
@@ -1656,10 +1657,11 @@ const MediaTracker = () => {
       {selectedItem && (
         <ItemDetailModal
           item={selectedItem}
-          onClose={() => setSelectedItem(null)}
+          onClose={() => { setSelectedItem(null); setOpenInEditMode(false); }}
           onSave={(item) => {
             saveItem(item);
             setSelectedItem(null);
+            setOpenInEditMode(false);
           }}
           onQuickSave={(item) => {
             // persist change but keep modal open
@@ -1668,12 +1670,14 @@ const MediaTracker = () => {
           onDelete={(item) => {
             deleteItem(item);
             setSelectedItem(null);
+            setOpenInEditMode(false);
           }}
           hexToRgba={hexToRgba}
           highlightColor={highlightColor}
           items={filteredAndSortedItems}
           onNavigate={setSelectedItem}
           allTags={allTags}
+          initialEditMode={openInEditMode}
         />
       )}
 
@@ -1738,8 +1742,15 @@ const MediaTracker = () => {
             setIsAdding(false);
             setSearchResultItem(null);
           }}
+          onDuplicate={(duplicate) => {
+            setIsAdding(false);
+            setSearchResultItem(null);
+            setSelectedItem(duplicate);
+            setOpenInEditMode(true);
+          }}
           initialItem={searchResultItem}
           allTags={allTags}
+          allItems={items}
         />
       )}
 

--- a/src/components/modals/AddEditModal.jsx
+++ b/src/components/modals/AddEditModal.jsx
@@ -3,11 +3,12 @@ import { X, Save } from 'lucide-react';
 import EditForm from '../forms/EditForm.jsx';
 import { STATUS_TYPES } from '../../constants/index.js';
 import { toast } from '../../services/toastService.js';
+import { isDuplicate } from '../../utils/commonUtils.js';
 
 /**
  * Modal for adding new items
  */
-const AddEditModal = ({ onClose, onSave, initialItem = null, allTags = [] }) => {
+const AddEditModal = ({ onClose, onSave, onDuplicate, initialItem = null, allTags = [], allItems = [] }) => {
   // Get today's date in YYYY-MM-DD format
   const getTodayDate = () => {
     const today = new Date();
@@ -65,6 +66,12 @@ const AddEditModal = ({ onClose, onSave, initialItem = null, allTags = [] }) => 
   const handleSave = () => {
     if (!item.title) {
       toast('Title is required', { type: 'error' });
+      return;
+    }
+    const duplicate = allItems.find((it) => isDuplicate([it], item));
+    if (duplicate) {
+      toast(`"${item.title}" is already in your library`, { type: 'warning' });
+      onDuplicate?.(duplicate);
       return;
     }
     onSave(item);

--- a/src/components/modals/ItemDetailModal.jsx
+++ b/src/components/modals/ItemDetailModal.jsx
@@ -14,8 +14,8 @@ import { useHalfStars } from '../../hooks/useHalfStars.js';
 /**
  * Modal for viewing and editing item details
  */
-const ItemDetailModal = ({ item, onClose, onSave, onDelete, onQuickSave, hexToRgba, highlightColor, items = [], onNavigate, allTags = [] }) => {
-  const [isEditing, setIsEditing] = useState(false);
+const ItemDetailModal = ({ item, onClose, onSave, onDelete, onQuickSave, hexToRgba, highlightColor, items = [], onNavigate, allTags = [], initialEditMode = false }) => {
+  const [isEditing, setIsEditing] = useState(initialEditMode);
   const [showStatusMenu, setShowStatusMenu] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isFetchingCover, setIsFetchingCover] = useState(false);

--- a/src/components/modals/__tests__/AddEditModal.test.jsx
+++ b/src/components/modals/__tests__/AddEditModal.test.jsx
@@ -266,6 +266,102 @@ describe('AddEditModal', () => {
     });
   });
 
+  describe('duplicate detection', () => {
+    it('should call onDuplicate and show warning toast when saving a duplicate book', async () => {
+      const user = userEvent.setup();
+      const onDuplicate = vi.fn();
+      render(
+        <AddEditModal
+          {...defaultProps}
+          onDuplicate={onDuplicate}
+          initialItem={sampleBook}
+          allItems={[sampleBook]}
+        />
+      );
+
+      await user.click(screen.getByText('Save Item'));
+
+      expect(toast).toHaveBeenCalledWith(
+        `"${sampleBook.title}" is already in your library`,
+        { type: 'warning' }
+      );
+      expect(onDuplicate).toHaveBeenCalledWith(sampleBook);
+      expect(defaultProps.onSave).not.toHaveBeenCalled();
+    });
+
+    it('should call onDuplicate and show warning toast when saving a duplicate movie', async () => {
+      const user = userEvent.setup();
+      const onDuplicate = vi.fn();
+      render(
+        <AddEditModal
+          {...defaultProps}
+          onDuplicate={onDuplicate}
+          initialItem={sampleMovie}
+          allItems={[sampleMovie]}
+        />
+      );
+
+      await user.click(screen.getByText('Save Item'));
+
+      expect(toast).toHaveBeenCalledWith(
+        `"${sampleMovie.title}" is already in your library`,
+        { type: 'warning' }
+      );
+      expect(onDuplicate).toHaveBeenCalledWith(sampleMovie);
+      expect(defaultProps.onSave).not.toHaveBeenCalled();
+    });
+
+    it('should call onSave normally when item is not a duplicate', async () => {
+      const user = userEvent.setup();
+      const onDuplicate = vi.fn();
+      render(
+        <AddEditModal
+          {...defaultProps}
+          onDuplicate={onDuplicate}
+          initialItem={sampleBook}
+          allItems={[sampleMovie]}
+        />
+      );
+
+      await user.click(screen.getByText('Save Item'));
+
+      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+      expect(onDuplicate).not.toHaveBeenCalled();
+    });
+
+    it('should call onSave normally when allItems is empty', async () => {
+      const user = userEvent.setup();
+      const onDuplicate = vi.fn();
+      render(
+        <AddEditModal
+          {...defaultProps}
+          onDuplicate={onDuplicate}
+          initialItem={sampleBook}
+          allItems={[]}
+        />
+      );
+
+      await user.click(screen.getByText('Save Item'));
+
+      expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+      expect(onDuplicate).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when onDuplicate prop is omitted and duplicate is found', async () => {
+      const user = userEvent.setup();
+      render(
+        <AddEditModal
+          {...defaultProps}
+          initialItem={sampleBook}
+          allItems={[sampleBook]}
+        />
+      );
+
+      await expect(user.click(screen.getByText('Save Item'))).resolves.not.toThrow();
+      expect(defaultProps.onSave).not.toHaveBeenCalled();
+    });
+  });
+
   describe('accessibility', () => {
     it('should have proper modal structure', () => {
       render(<AddEditModal {...defaultProps} />);

--- a/src/components/modals/__tests__/ItemDetailModal.test.jsx
+++ b/src/components/modals/__tests__/ItemDetailModal.test.jsx
@@ -87,6 +87,20 @@ describe('ItemDetailModal', () => {
   });
 
   describe('edit mode', () => {
+    it('should start in edit mode when initialEditMode is true', () => {
+      render(<ItemDetailModal {...defaultProps} initialEditMode={true} />);
+
+      expect(screen.getByTitle('Save')).toBeInTheDocument();
+      expect(screen.queryByTitle('Edit')).not.toBeInTheDocument();
+    });
+
+    it('should start in view mode when initialEditMode is false', () => {
+      render(<ItemDetailModal {...defaultProps} initialEditMode={false} />);
+
+      expect(screen.getByTitle('Edit')).toBeInTheDocument();
+      expect(screen.queryByTitle('Save')).not.toBeInTheDocument();
+    });
+
     it('should switch to edit mode when edit button clicked', async () => {
       const user = userEvent.setup();
       render(<ItemDetailModal {...defaultProps} />);


### PR DESCRIPTION
## Summary
- Wire the existing `isDuplicate()` utility into `AddEditModal` so duplicate items are caught before `onSave` is called
- When a duplicate is detected, show a warning toast `"<title>" is already in your library` and open the existing item in edit mode via `ItemDetailModal`
- Add `initialEditMode` prop to `ItemDetailModal` so it can be opened directly in edit state

## Root Cause
`AddEditModal` never received the items list, so `isDuplicate()` (which already existed in `commonUtils.js` and was used for CSV imports) was never called for single-item additions.

## Test Plan
- [x] `AddEditModal`: 5 new tests covering duplicate book, duplicate movie, non-duplicate, empty list, and missing `onDuplicate` prop
- [x] `ItemDetailModal`: 2 new tests for `initialEditMode=true` and `initialEditMode=false`
- [x] `npm run test -- --run` passes (1357 tests)
- [x] `npm run test:coverage` meets thresholds
- [x] `npm run lint` passes (no new errors beyond pre-existing baseline)
- [x] `npm run build` succeeds

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)