### PR TITLE
fix: correctness bugs (useOmdbApi, useSelection, header-height effect)

### DIFF
--- a/src/MediaTracker.jsx
+++ b/src/MediaTracker.jsx
@@ -654,8 +654,10 @@ const MediaTracker = () => {
     const updateHeaderHeight = () => {
       if (headerRef.current) {
         const height = headerRef.current.offsetHeight;
-        if (height > 0 && height !== headerHeight) {
-          setHeaderHeight(height);
+        if (height > 0) {
+          // Functional update avoids depending on headerHeight, so the effect
+          // doesn't re-subscribe the ResizeObserver/listener on every height change.
+          setHeaderHeight(prev => (prev !== height ? height : prev));
         }
       }
     };
@@ -679,7 +681,7 @@ const MediaTracker = () => {
       }
       window.removeEventListener('resize', updateHeaderHeight);
     };
-  }, [headerHeight]);
+  }, []);
 
 
 

--- a/src/hooks/__tests__/useOmdbApi.test.js
+++ b/src/hooks/__tests__/useOmdbApi.test.js
@@ -134,8 +134,32 @@ describe('useOmdbApi', () => {
 
   it('should return hasApiKey boolean', () => {
     const { result } = renderHook(() => useOmdbApi());
-    
+
     expect(typeof result.current.hasApiKey).toBe('boolean');
+  });
+
+  it('should derive hasApiKey reactively from the current key state', async () => {
+    getConfig.mockReturnValue('');
+
+    const { result } = renderHook(() => useOmdbApi());
+
+    expect(result.current.hasApiKey).toBe(false);
+
+    act(() => {
+      result.current.updateApiKey('reactive-key');
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasApiKey).toBe(true);
+    });
+
+    act(() => {
+      result.current.updateApiKey('');
+    });
+
+    await waitFor(() => {
+      expect(result.current.hasApiKey).toBe(false);
+    });
   });
 
   it('should maintain API key state across re-renders', async () => {

--- a/src/hooks/__tests__/useSelection.test.js
+++ b/src/hooks/__tests__/useSelection.test.js
@@ -155,6 +155,16 @@ describe('useSelection', () => {
       expect(result.current.selectedCount).toBe(0);
     });
 
+    it('should not throw when called with undefined', () => {
+      const { result } = renderHook(() => useSelection());
+
+      act(() => {
+        result.current.selectAll(undefined);
+      });
+
+      expect(result.current.selectedCount).toBe(0);
+    });
+
     it('should override previous selections', () => {
       const { result } = renderHook(() => useSelection());
 

--- a/src/hooks/useOmdbApi.js
+++ b/src/hooks/useOmdbApi.js
@@ -1,5 +1,5 @@
-import { useState, useEffect } from 'react';
-import { getConfig, saveConfig, hasApiKey } from '../config.js';
+import { useState, useEffect, useCallback } from 'react';
+import { getConfig, saveConfig } from '../config.js';
 import { loadAllSettings, saveAllSettings } from '../services/configService.js';
 
 
@@ -44,26 +44,27 @@ export const useOmdbApi = (storage = null) => {
     }
   }, [storage]);
 
-  const updateApiKey = (key) => {
+  const updateApiKey = useCallback((key) => {
     setOmdbApiKey(key);
     saveConfig({ omdbApiKey: key });
     if (storage && storage.isConnected()) {
       saveAllSettings(storage, { omdbApiKey: key }).catch(err => console.warn('Error saving OMDb API key to file:', err));
     }
-  };
+  }, [storage]);
 
-  const updateTmdbApiKey = (key) => {
+  const updateTmdbApiKey = useCallback((key) => {
     setTmdbApiKey(key);
     saveConfig({ tmdbApiKey: key });
     if (storage && storage.isConnected()) {
       saveAllSettings(storage, { tmdbApiKey: key }).catch(err => console.warn('Error saving TMDB API key to file:', err));
     }
-  };
+  }, [storage]);
 
   return {
     omdbApiKey,
     updateApiKey,
-    hasApiKey: hasApiKey(),
+    // Derive from reactive state so this updates when the key changes
+    hasApiKey: Boolean(omdbApiKey),
     tmdbApiKey,
     updateTmdbApiKey,
   };

--- a/src/hooks/useSelection.js
+++ b/src/hooks/useSelection.js
@@ -38,7 +38,7 @@ export const useSelection = () => {
    * Select all items
    */
   const selectAll = (items) => {
-    setSelectedIds(new Set(items.map(item => item.id)));
+    setSelectedIds(new Set((items || []).map(item => item.id)));
   };
 
   /**


### PR DESCRIPTION
First of six small PRs hardening the codebase (see the series for context).

**Correctness fixes (independent of any refactor):**
- `useOmdbApi`: wrap `updateApiKey`/`updateTmdbApiKey` in `useCallback` with the `storage` dep (avoids a stale `storage` closure after reconnection); derive `hasApiKey` from reactive key state instead of calling config on every render.
- `useSelection.selectAll`: guard against `undefined` items.
- MediaTracker header-height `useLayoutEffect`: use a functional `setState` and drop `headerHeight` from deps so it no longer re-subscribes the ResizeObserver/resize listener on every height change.

Adds regression tests for reactive `hasApiKey` and `selectAll(undefined)`. Lint unchanged; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)