### PR TITLE
refactor: remove duplication and dead code

### DIFF
--- a/src/MediaTracker.jsx
+++ b/src/MediaTracker.jsx
@@ -115,17 +115,13 @@ const MediaTracker = () => {
     storageInfo,
     isLoading,
     loadProgress,
-    undoStack,
     initializeStorage,
     loadItems,
     saveItem,
     deleteItem,
-    deleteItems,
-    undoLastDelete,
     selectStorage,
     disconnectStorage,
     getAvailableStorageOptions,
-    applyBatchEdit,
     refreshStorageAdapter
   } = useItems();
 
@@ -151,13 +147,10 @@ const MediaTracker = () => {
     setSearchTerm,
     setFilterType,
     setSortBy,
-    setSortOrder,
     setFilterRating,
     setFilterMaxRating,
     setFilterHasReview,
     setFilterHasCover,
-    setFilterTags,
-    setFilterStatuses,
     setFilterRecent,
     setFilterStartDate,
     setFilterEndDate,
@@ -165,7 +158,6 @@ const MediaTracker = () => {
     toggleTagFilter,
     toggleStatusFilter,
     clearFilters,
-    cycleFilterType,
     toggleSortOrder
   } = useFilters(items);
 
@@ -177,7 +169,6 @@ const MediaTracker = () => {
     toggleItemSelection,
     selectAll,
     clearSelection,
-    isItemSelected, // Keep for non-rendering uses
     getSelectedItems
   } = useSelection();
 
@@ -332,7 +323,7 @@ const MediaTracker = () => {
       let lastProgressUpdate = Date.now();
       const progressThrottleMs = 100; // Update UI at most every 100ms
 
-      const progressCb = ({ processed, added, total, currentFile, filesCompleted, totalFiles }) => {
+      const progressCb = ({ processed, added, total, currentFile }) => {
         const now = Date.now();
         // Always update on first/last item, otherwise throttle
         const isFirstOrLast = processed === 0 || processed === total;
@@ -626,12 +617,12 @@ const MediaTracker = () => {
     }
 
     // Try multiple strategies for maximum compatibility
-    try { window.scrollTo({ top: 0, behavior: 'smooth' }); } catch (_) { }
-    try { document.documentElement && (document.documentElement.scrollTop = 0); } catch (_) { }
-    try { document.body && (document.body.scrollTop = 0); } catch (_) { }
+    try { window.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* ignore */ }
+    try { document.documentElement && (document.documentElement.scrollTop = 0); } catch { /* ignore */ }
+    try { document.body && (document.body.scrollTop = 0); } catch { /* ignore */ }
     const scrollingEl = document.scrollingElement;
     if (scrollingEl && typeof scrollingEl.scrollTo === 'function') {
-      try { scrollingEl.scrollTo({ top: 0, behavior: 'smooth' }); } catch (_) { }
+      try { scrollingEl.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* ignore */ }
     }
   };
 
@@ -687,18 +678,18 @@ const MediaTracker = () => {
   useEffect(() => {
     if (!showStorageSelector) {
       // Try multiple strategies for maximum compatibility across desktop and mobile
-      try { window.scrollTo({ top: 0, behavior: 'smooth' }); } catch (_) { }
-      try { document.documentElement && (document.documentElement.scrollTop = 0); } catch (_) { }
-      try { document.body && (document.body.scrollTop = 0); } catch (_) { }
+      try { window.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* ignore */ }
+      try { document.documentElement && (document.documentElement.scrollTop = 0); } catch { /* ignore */ }
+      try { document.body && (document.body.scrollTop = 0); } catch { /* ignore */ }
       const scrollingEl = document.scrollingElement;
       if (scrollingEl && typeof scrollingEl.scrollTo === 'function') {
-        try { scrollingEl.scrollTo({ top: 0, behavior: 'smooth' }); } catch (_) { }
+        try { scrollingEl.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* ignore */ }
       }
     }
   }, [showStorageSelector]);
 
   // Keyboard navigation setup
-  const { focusedIndex, focusedId, registerCardRef, isItemFocused, resetFocus } = useKeyboardNavigation({ // focusedId used directly for performance
+  const { focusedId, registerCardRef } = useKeyboardNavigation({ // focusedId used directly for performance
     items: filteredAndSortedItems,
     cardSize,
     storageAdapter,

--- a/src/components/ToastProvider.jsx
+++ b/src/components/ToastProvider.jsx
@@ -1,11 +1,6 @@
-import React, { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { registerToast } from '../services/toastService.js';
-
-const ToastContext = createContext(null);
-
-export const useToast = () => {
-  return useContext(ToastContext);
-};
+import { ToastContext } from '../hooks/useToast.js';
 
 let idCounter = 1;
 

--- a/src/components/__tests__/ToastProvider.test.jsx
+++ b/src/components/__tests__/ToastProvider.test.jsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { ToastProvider, useToast } from '../ToastProvider.jsx';
+import { ToastProvider } from '../ToastProvider.jsx';
+import { useToast } from '../../hooks/useToast.js';
 import * as toastService from '../../services/toastService.js';
 
 // Mock toastService

--- a/src/components/modals/FilterModal.jsx
+++ b/src/components/modals/FilterModal.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
-import { Star, Layers, BookOpen, CheckCircle, PlayCircle, XCircle } from 'lucide-react';
-import { STATUS_LABELS, STATUS_ICONS } from "../../constants";
+import { STATUS_LABELS } from "../../constants";
+import { getStatusIcon } from '../../utils/statusUtils.jsx';
 
 const FilterModal = ({
     // Filter state
@@ -34,27 +34,6 @@ const FilterModal = ({
         setFilterRecent(value);
     }, [setFilterRecent]);
 
-    // Get the appropriate icon component for a status
-    const getStatusIcon = (status) => {
-        const iconName = STATUS_ICONS[status];
-        const iconProps = { className: "w-4 h-4" };
-
-        switch (iconName) {
-            case 'layers':
-                return <Layers {...iconProps} />;
-            case 'book-open':
-                return <BookOpen {...iconProps} />;
-            case 'check-circle':
-                return <CheckCircle {...iconProps} />;
-            case 'play-circle':
-                return <PlayCircle {...iconProps} />;
-            case 'x-circle':
-                return <XCircle {...iconProps} />;
-            default:
-                return <Layers {...iconProps} />;
-        }
-    };
-
     return (
         <>
             {/* Expanded Filters */}
@@ -80,7 +59,7 @@ const FilterModal = ({
                                                 }`}
                                             style={filterStatuses.includes(status) ? { backgroundColor: 'var(--mt-highlight)', color: 'white' } : {}}
                                         >
-                                            {getStatusIcon(status)}
+                                            {getStatusIcon(status, "w-4 h-4")}
                                             {STATUS_LABELS[status]}
                                         </button>
                                     ))

--- a/src/components/modals/ItemDetailModal.jsx
+++ b/src/components/modals/ItemDetailModal.jsx
@@ -3,10 +3,10 @@ import { X, Save, ChevronDown, Edit, Trash2 } from 'lucide-react';
 import EditForm from '../forms/EditForm.jsx';
 import ViewDetails from '../cards/ViewDetails.jsx';
 import { STATUS_TYPES, KEYBOARD_SHORTCUTS } from '../../constants/index.js';
-import { STATUS_LABELS, STATUS_ICONS, STATUS_COLORS } from '../../constants/index.js';
-import { Bookmark, BookOpen, CheckCircle, PlayCircle, Layers, XCircle } from 'lucide-react';
+import { STATUS_LABELS } from '../../constants/index.js';
 import { fetchCoverForItem } from '../../utils/coverUtils.js';
 import { getStatusColor } from '../../utils/colorUtils.js';
+import { getStatusIcon } from '../../utils/statusUtils.jsx';
 import { toast } from '../../services/toastService.js';
 import StarRating from '../StarRating.jsx';
 import { useHalfStars } from '../../hooks/useHalfStars.js';
@@ -122,26 +122,6 @@ const ItemDetailModal = ({ item, onClose, onSave, onDelete, onQuickSave, hexToRg
       }
     } finally {
       setIsFetchingCover(false);
-    }
-  };
-
-  const getIconForStatus = (status, className = '') => {
-    const iconType = STATUS_ICONS[status];
-    switch (iconType) {
-      case 'bookmark':
-        return <Bookmark className={className} />;
-      case 'book-open':
-        return <BookOpen className={className} />;
-      case 'check-circle':
-        return <CheckCircle className={className} />;
-      case 'play-circle':
-        return <PlayCircle className={className} />;
-      case 'layers':
-        return <Layers className={className} />;
-      case 'x-circle':
-        return <XCircle className={className} />;
-      default:
-        return <Bookmark className={className} />;
     }
   };
 
@@ -320,7 +300,7 @@ const ItemDetailModal = ({ item, onClose, onSave, onDelete, onQuickSave, hexToRg
                 onStatusChange={handleStatusClick}
                 currentStatus={editedItem.status}
                 getStatusColor={getStatusColor}
-                getStatusIcon={getIconForStatus}
+                getStatusIcon={getStatusIcon}
                 STATUS_LABELS={STATUS_LABELS}
                 halfStarsEnabled={halfStarsEnabled}
                 showStatusMenu={showStatusMenu}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -29,6 +29,16 @@ export const STATUS_TYPES = {
   }
 };
 
+/**
+ * Canonical default status for an item type. Used when an item has no status
+ * (e.g. legacy markdown, CSV/import rows). Single source of truth — import this
+ * instead of re-deriving the default inline.
+ * @param {string} type - Item type ('book' or 'movie')
+ * @returns {string} Default status value
+ */
+export const getDefaultStatus = (type) =>
+  type === 'book' ? STATUS_TYPES.BOOK.READ : STATUS_TYPES.MOVIE.WATCHED;
+
 export const STATUS_LABELS = {
   'to-read': 'To Read',
   'reading': 'Reading',

--- a/src/hooks/useToast.js
+++ b/src/hooks/useToast.js
@@ -1,0 +1,14 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Context carrying the toast API ({ show, hide }). Provided by ToastProvider.
+ * Kept in its own module so ToastProvider.jsx only exports a component
+ * (required for React Fast Refresh).
+ */
+export const ToastContext = createContext(null);
+
+/**
+ * Access the toast API from within the ToastProvider tree.
+ * @returns {{ show: Function, hide: Function } | null}
+ */
+export const useToast = () => useContext(ToastContext);

--- a/src/services/fileSystemStorage.js
+++ b/src/services/fileSystemStorage.js
@@ -228,7 +228,10 @@ export class FileSystemStorage extends StorageAdapter {
       // Ensure the item object knows its filename so callers can update the same file later
       item.filename = filename;
 
-      const fileExists = await this.fileExists(filename).catch(() => false);
+      const fileExists = await this.fileExists(filename).catch((err) => {
+        console.warn('[Storage][FS] fileExists check failed, assuming new file', filename, err);
+        return false;
+      });
       if (fileExists) {
         console.debug('[Storage][FS] updating existing file', filename);
       } else {

--- a/src/utils/csvUtils.js
+++ b/src/utils/csvUtils.js
@@ -1,4 +1,4 @@
-import { CSV_FORMATS, STATUS_TYPES } from '../constants/index.js';
+import { CSV_FORMATS, STATUS_TYPES, getDefaultStatus } from '../constants/index.js';
 import { toast } from '../services/toastService.js';
 
 /**
@@ -264,7 +264,7 @@ export const mapGenericRow = (r) => {
   // Try to map status, with fallback to default
   let status = r['status'] || r['Status'] || '';
   if (!status) {
-    status = type === 'book' ? STATUS_TYPES.BOOK.READ : STATUS_TYPES.MOVIE.WATCHED;
+    status = getDefaultStatus(type);
   }
   
   return {

--- a/src/utils/importUtils.js
+++ b/src/utils/importUtils.js
@@ -2,6 +2,7 @@ import { parseCSV, detectCSVFormat, mapGoodreadsRow, mapLetterboxdRow, mapGeneri
 import { isDuplicate, normalizeForCompare, normalizeISBNForCompare, sanitizeDisplayString } from './commonUtils.js';
 import { getBookByISBN, OpenLibraryError } from '../services/openLibraryService.js';
 import { getMovieByTitleYear, OMDBError } from '../services/omdbService.js';
+import { getDefaultStatus } from '../constants/index.js';
 import JSZip from 'jszip';
 
 /**
@@ -49,7 +50,7 @@ const processLetterboxdRow = async (row, filename = '', omdbApiKey = null, onPro
 
   // Call progress bridge before OMDb fetch to keep UI responsive
   if (typeof onProgress === 'function') {
-    try { onProgress(); } catch (e) { /* swallow */ }
+    try { onProgress(); } catch (e) { console.warn('onProgress callback threw', e); }
   }
 
   // Skip OMDB enrichment if requested (e.g., after quota exceeded)
@@ -75,7 +76,7 @@ const processLetterboxdRow = async (row, filename = '', omdbApiKey = null, onPro
 
   // Call progress bridge after OMDb fetch
   if (typeof onProgress === 'function') {
-    try { onProgress(); } catch (e) { /* swallow */ }
+    try { onProgress(); } catch (e) { console.warn('onProgress callback threw', e); }
   }
 
   // Ensure type
@@ -439,7 +440,7 @@ export const processCSVImport = async (file, existingItems, saveItem, onProgress
         // Create a progress bridge that injects current counters when invoked
         const progressBridge = (...args) => {
           if (typeof onProgress === 'function') {
-            try { onProgress({ processed, added, total }); } catch (e) { /* swallow */ }
+            try { onProgress({ processed, added, total }); } catch (e) { console.warn('onProgress callback threw', e); }
           }
         };
         try {
@@ -620,7 +621,7 @@ export const processCSVImport = async (file, existingItems, saveItem, onProgress
           year: mergedYear,
           rating: normalizeRating(m.rating || m.Rating || 0),
           tags: m.tags || [],
-          status: m.status || 'unread',
+          status: m.status || getDefaultStatus(m.type || 'book'),
           coverUrl: mergedCover,
           dateRead: m.dateRead || '',
           dateWatched: m.dateWatched || '',

--- a/src/utils/markdownUtils.js
+++ b/src/utils/markdownUtils.js
@@ -1,16 +1,7 @@
 // Markdown parsing and generation utilities
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { STATUS_TYPES } from '../constants/index.js';
-
-/**
- * Get default status for item type (for backward compatibility)
- * @param {string} type - Item type ('book' or 'movie')
- * @returns {string} Default status value
- */
-const getDefaultStatus = (type) => {
-  return type === 'book' ? STATUS_TYPES.BOOK.READ : STATUS_TYPES.MOVIE.WATCHED;
-};
+import { getDefaultStatus } from '../constants/index.js';
 
 /**
  * Parse markdown content with YAML frontmatter


### PR DESCRIPTION
Second of six hardening PRs.

- **Dedupe status icons:** delete the local `getStatusIcon`/`getIconForStatus` in `ItemDetailModal` and `FilterModal`; import the canonical `getStatusIcon` from `utils/statusUtils.jsx` (CLAUDE.md's single-source rule). This also fixes `FilterModal` not rendering the bookmark icon for `to-read`/`to-watch`.
- **Single `getDefaultStatus(type)`** in `constants/index.js`, used by `markdownUtils`, `csvUtils`, and `importUtils` — replaces an invalid `'unread'` default in the import path.
- Remove unused hook destructures / callback args in `MediaTracker`; convert empty `catch (_) {}` blocks to `catch { /* ignore */ }`.
- Log previously-swallowed `onProgress` and `fileExists` errors.
- Move `useToast` + `ToastContext` into `hooks/useToast.js` so `ToastProvider.jsx` only exports a component (fixes a Fast Refresh lint error).

**Lint: 135 → 101 problems.** All tests pass; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)