### PR TITLE
feat: accessibility — dialog semantics, card roles, stable keys

### DIFF
--- a/src/components/cards/ItemCard.jsx
+++ b/src/components/cards/ItemCard.jsx
@@ -38,10 +38,18 @@ const ItemCard = memo(({
     return 'empty';
   }, [halfStarsEnabled]);
 
+  const creator = item.author || item.director;
+  const ariaLabel = `${item.title}${creator ? `, ${creator}` : ''}, ${item.type}${
+    item.status ? `, ${STATUS_LABELS[item.status]}` : ''
+  }${selectionMode ? (isSelected ? ', selected' : ', not selected') : ''}`;
+
   return (
     <div
       ref={(el) => registerCardRef(item.id, el)}
       onClick={handleClick}
+      role="button"
+      aria-label={ariaLabel}
+      aria-pressed={selectionMode ? isSelected : undefined}
       className={`bg-slate-800/30 border rounded-lg overflow-hidden cursor-pointer transition-all relative w-full flex flex-col h-full ${
         isFocused ? 'ring-2 ring-blue-500' :
         isSelected ? 'ring-2 ring-yellow-500' :
@@ -51,7 +59,9 @@ const ItemCard = memo(({
       {/* Selection checkbox */}
       {selectionMode && (
         <div className="absolute top-2 left-2 z-10">
-          <div className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
+          <div
+            aria-hidden="true"
+            className={`w-5 h-5 rounded border-2 flex items-center justify-center ${
             isSelected ? 'bg-yellow-500 border-yellow-500' : 'bg-slate-800 border-slate-400'
           }`}>
             {isSelected && (
@@ -106,9 +116,9 @@ const ItemCard = memo(({
         {/* Tags */}
         {item.tags && item.tags.length > 0 && cardSize !== 'tiny' && (
           <div className="flex flex-wrap gap-1 mt-2">
-            {item.tags.slice(0, 3).map((tag, i) => (
+            {item.tags.slice(0, 3).map((tag) => (
               <span
-                key={i}
+                key={tag}
                 className={`px-2 py-1 rounded-full ${cardSize === 'small' ? 'text-xs' : 'text-xs'}`}
                 style={{ backgroundColor: hexToRgba(highlightColor, 0.12), color: 'white' }}
               >

--- a/src/components/cards/ViewDetails.jsx
+++ b/src/components/cards/ViewDetails.jsx
@@ -155,9 +155,9 @@ const ViewDetails = ({ item, hexToRgba, highlightColor, hideRating = false, onFe
         <div>
           <div className="text-sm font-medium text-slate-400 mb-2">Cast</div>
           <div className="flex flex-wrap gap-2">
-            {item.actors.map((actor, i) => (
+            {item.actors.map((actor) => (
               <span
-                key={i}
+                key={actor}
                 className="px-3 py-1 bg-slate-700 rounded-full text-sm"
               >
                 {actor}
@@ -214,9 +214,9 @@ const ViewDetails = ({ item, hexToRgba, highlightColor, hideRating = false, onFe
             Tags
           </div>
           <div className="flex flex-wrap gap-2">
-            {item.tags.map((tag, i) => (
+            {item.tags.map((tag) => (
               <span
-                key={i}
+                key={tag}
                 className="px-3 py-1 rounded-full text-sm"
                 style={{
                   backgroundColor: hexToRgba(highlightColor, 0.12),

--- a/src/components/cards/__tests__/ItemCard.test.jsx
+++ b/src/components/cards/__tests__/ItemCard.test.jsx
@@ -423,4 +423,33 @@ describe('ItemCard', () => {
       expect(title.textContent).toBe(longTitle);
     });
   });
+
+  describe('accessibility', () => {
+    it('should expose the card as a button with a descriptive label', () => {
+      render(<ItemCard {...defaultProps} />);
+
+      const card = screen.getByRole('button', { name: /The Great Gatsby/i });
+      expect(card).toBeInTheDocument();
+      expect(card).toHaveAttribute('aria-label', expect.stringContaining('F. Scott Fitzgerald'));
+    });
+
+    it('should reflect selection state via aria-pressed in selection mode', () => {
+      const props = {
+        ...defaultProps,
+        selectionMode: true,
+        selectedIds: new Set([sampleBook.id])
+      };
+      render(<ItemCard {...props} />);
+
+      const card = screen.getByRole('button', { name: /The Great Gatsby/i });
+      expect(card).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('should not set aria-pressed when not in selection mode', () => {
+      render(<ItemCard {...defaultProps} />);
+
+      const card = screen.getByRole('button', { name: /The Great Gatsby/i });
+      expect(card).not.toHaveAttribute('aria-pressed');
+    });
+  });
 });

--- a/src/components/forms/EditForm.jsx
+++ b/src/components/forms/EditForm.jsx
@@ -227,9 +227,9 @@ const EditForm = ({ item, onChange, fromSearch = false, allTags = [] }) => {
               </button>
             </div>
             <div className="flex flex-wrap gap-2">
-              {item.actors.map((actor, i) => (
+              {item.actors.map((actor) => (
                 <span
-                  key={i}
+                  key={actor}
                   className="px-3 py-1 bg-slate-600 rounded-full text-sm flex items-center gap-2"
                 >
                   {actor}
@@ -304,9 +304,9 @@ const EditForm = ({ item, onChange, fromSearch = false, allTags = [] }) => {
           </button>
         </div>
         <div className="flex flex-wrap gap-2">
-          {item.tags.map((tag, i) => (
+          {item.tags.map((tag) => (
             <span
-              key={i}
+              key={tag}
               className="px-3 py-1 bg-slate-600 rounded-full text-sm flex items-center gap-2"
             >
               {tag}

--- a/src/components/modals/AddEditModal.jsx
+++ b/src/components/modals/AddEditModal.jsx
@@ -136,12 +136,15 @@ const AddEditModal = ({ onClose, onSave, onDuplicate, initialItem = null, allTag
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4 z-50">
-      <div 
+      <div
         ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="addedit-modal-title"
         className="bg-slate-800 border border-slate-700 rounded-lg w-full h-full sm:max-w-2xl sm:w-full sm:max-h-[90vh] sm:h-auto overflow-y-auto"
       >
         <div className="sticky top-0 bg-slate-800 border-b border-slate-700 p-4 flex items-center justify-between">
-          <h2 className="text-lg sm:text-xl font-bold">Add New Item</h2>
+          <h2 id="addedit-modal-title" className="text-lg sm:text-xl font-bold">Add New Item</h2>
           <button
             onClick={onClose}
             className="p-2 hover:bg-slate-700 rounded transition min-h-[44px] min-w-[44px] flex items-center justify-center"

--- a/src/components/modals/BatchEditModal.jsx
+++ b/src/components/modals/BatchEditModal.jsx
@@ -89,9 +89,14 @@ const BatchEditModal = ({ onClose, onApply, selectedItems = [], isProcessing = f
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center p-2 sm:p-4 z-50">
-      <div className="bg-slate-800 border border-slate-700 rounded-lg w-full h-full sm:max-w-4xl sm:w-full sm:max-h-[90vh] sm:h-auto overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="batchedit-modal-title"
+        className="bg-slate-800 border border-slate-700 rounded-lg w-full h-full sm:max-w-4xl sm:w-full sm:max-h-[90vh] sm:h-auto overflow-y-auto"
+      >
         <div className="sticky top-0 bg-slate-800 border-b border-slate-700 p-4 flex items-center justify-between">
-          <h2 className="text-lg sm:text-xl font-bold">
+          <h2 id="batchedit-modal-title" className="text-lg sm:text-xl font-bold">
             {isProcessing ? 'Updating Items...' : 'Batch Edit Preview'}
           </h2>
           {!isProcessing && (

--- a/src/components/modals/GoogleDriveConfigModal.jsx
+++ b/src/components/modals/GoogleDriveConfigModal.jsx
@@ -27,18 +27,23 @@ const GoogleDriveConfigModal = ({ onClose, onConnect }) => {
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-slate-800 rounded-lg border border-slate-600 w-full max-w-md">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="gdriveconfig-modal-title"
+        className="bg-slate-800 rounded-lg border border-slate-600 w-full max-w-md"
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-slate-600">
           <div className="flex items-center gap-3">
-            <div 
+            <div
               className="w-10 h-10 rounded-lg flex items-center justify-center"
               style={{ backgroundColor: 'var(--mt-highlight-alpha)' }}
             >
               <FolderOpen className="w-5 h-5" style={{ color: 'var(--mt-highlight)' }} />
             </div>
             <div>
-              <h3 className="text-lg font-semibold text-white">Configure Google Drive</h3>
+              <h3 id="gdriveconfig-modal-title" className="text-lg font-semibold text-white">Configure Google Drive</h3>
               <p className="text-sm text-slate-400">Choose your folder name</p>
             </div>
           </div>

--- a/src/components/modals/HelpModal.jsx
+++ b/src/components/modals/HelpModal.jsx
@@ -7,9 +7,14 @@ import { X } from 'lucide-react';
 const HelpModal = ({ onClose }) => {
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center p-4 z-50 overflow-y-auto">
-      <div className="bg-slate-800 border border-slate-700 rounded-lg max-w-3xl w-full p-6 mt-4 mb-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="help-modal-title"
+        className="bg-slate-800 border border-slate-700 rounded-lg max-w-3xl w-full p-6 mt-4 mb-4 max-h-[calc(100vh-2rem)] overflow-y-auto"
+      >
         <div className="flex items-start justify-between mb-4">
-          <h2 className="text-xl font-bold">Keyboard shortcuts</h2>
+          <h2 id="help-modal-title" className="text-xl font-bold">Keyboard shortcuts</h2>
           <button 
             onClick={onClose} 
             className="p-1 hover:bg-slate-700 rounded"

--- a/src/components/modals/ItemDetailModal.jsx
+++ b/src/components/modals/ItemDetailModal.jsx
@@ -238,11 +238,14 @@ const ItemDetailModal = ({ item, onClose, onSave, onDelete, onQuickSave, hexToRg
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4 z-50">
       <div
         ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="itemdetail-modal-title"
         className="bg-slate-800 border border-slate-700 rounded-lg w-full h-full sm:max-w-2xl sm:w-full sm:max-h-[90vh] sm:h-auto overflow-y-auto"
       >
         <div className="sticky top-0 bg-slate-800 border-b border-slate-700 p-4 flex items-center justify-between z-10">
           <div className="flex items-center gap-3 min-w-0 flex-1">
-            <h2 className="text-lg sm:text-xl font-bold truncate flex-1">{item.title}</h2>
+            <h2 id="itemdetail-modal-title" className="text-lg sm:text-xl font-bold truncate flex-1">{item.title}</h2>
           </div>
           {/* Right-side controls: action buttons only */}
           <div className="flex gap-2 flex-shrink-0">

--- a/src/components/modals/ObsidianBaseModal.jsx
+++ b/src/components/modals/ObsidianBaseModal.jsx
@@ -27,12 +27,17 @@ const ObsidianBaseModal = ({ onClose, onCreate }) => {
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div className="bg-slate-800 border border-slate-700 rounded-lg max-w-md w-full">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="obsidianbase-modal-title"
+        className="bg-slate-800 border border-slate-700 rounded-lg max-w-md w-full"
+      >
         <div className="p-4 border-b border-slate-700">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <Layers className="w-5 h-5" style={{ color: 'var(--mt-highlight)' }} />
-              <h2 className="text-lg font-semibold">Initialize Obsidian Base</h2>
+              <h2 id="obsidianbase-modal-title" className="text-lg font-semibold">Initialize Obsidian Base</h2>
             </div>
             <button onClick={onClose} className="text-slate-400 hover:text-white transition-colors">
               <X className="w-5 h-5" />

--- a/src/components/modals/SearchModal.jsx
+++ b/src/components/modals/SearchModal.jsx
@@ -241,10 +241,15 @@ const SearchModal = ({ onClose, onSelect }) => {
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-2 sm:p-4 z-50">
-      <div className="bg-slate-800 border border-slate-700 rounded-lg w-full h-full sm:max-w-4xl sm:w-full sm:max-h-[90vh] sm:h-auto overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="search-modal-title"
+        className="bg-slate-800 border border-slate-700 rounded-lg w-full h-full sm:max-w-4xl sm:w-full sm:max-h-[90vh] sm:h-auto overflow-y-auto"
+      >
         <div className="sticky top-0 bg-slate-800 border-b border-slate-700 p-4">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-lg sm:text-xl font-bold">Search Books & Movies</h2>
+            <h2 id="search-modal-title" className="text-lg sm:text-xl font-bold">Search Books & Movies</h2>
             <button
               onClick={onClose}
               className="p-2 hover:bg-slate-700 rounded transition min-h-[44px] min-w-[44px] flex items-center justify-center"

--- a/src/components/modals/SettingsModal.jsx
+++ b/src/components/modals/SettingsModal.jsx
@@ -64,13 +64,18 @@ const SettingsModal = ({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div className="bg-slate-800 border border-slate-700 rounded-lg max-w-md w-full max-h-[90vh] flex flex-col">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="settings-modal-title"
+        className="bg-slate-800 border border-slate-700 rounded-lg max-w-md w-full max-h-[90vh] flex flex-col"
+      >
 
         {/* Header */}
         <div className="p-4 border-b border-slate-700 flex items-center justify-between shrink-0">
           <div className="flex items-center gap-2">
             <Settings className="w-5 h-5" style={{ color: 'var(--mt-highlight)' }} />
-            <h2 className="text-lg font-semibold">Settings</h2>
+            <h2 id="settings-modal-title" className="text-lg font-semibold">Settings</h2>
           </div>
           <button onClick={onClose} aria-label="Close settings" className="text-slate-400 hover:text-white transition-colors">
             <X className="w-5 h-5" />

--- a/src/components/modals/TrashModal.jsx
+++ b/src/components/modals/TrashModal.jsx
@@ -92,10 +92,15 @@ const TrashModal = ({ storageAdapter, onClose, onRestore }) => {
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-start justify-center p-4 z-50 overflow-y-auto">
-      <div className="bg-slate-800 border border-slate-700 rounded-lg max-w-4xl w-full p-6 mt-4 mb-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="trash-modal-title"
+        className="bg-slate-800 border border-slate-700 rounded-lg max-w-4xl w-full p-6 mt-4 mb-4 max-h-[calc(100vh-2rem)] overflow-y-auto"
+      >
         <div className="flex items-start justify-between mb-4">
           <div>
-            <h2 className="text-xl font-bold">Trash</h2>
+            <h2 id="trash-modal-title" className="text-xl font-bold">Trash</h2>
             <p className="text-sm text-slate-400 mt-1">
               {trashedItems.length} {trashedItems.length === 1 ? 'item' : 'items'} in trash
             </p>


### PR DESCRIPTION
Third of six hardening PRs. **Stacked on #73** (`fix/remove-duplication`).

- `role="dialog"` + `aria-modal="true"` + `aria-labelledby` (with id'd headings) on AddEdit, ItemDetail, Search, Help, BatchEdit, ObsidianBase, Trash, Settings, and GoogleDriveConfig modals.
- `ItemCard`: expose `role="button"` with a descriptive `aria-label` (title, creator, type, status) and `aria-pressed` reflecting selection; mark the decorative selection checkbox `aria-hidden`. (No `tabIndex` — the app uses its own grid keyboard-nav model.)
- Replace index-based React keys with stable value keys for tag/actor lists in `ItemCard`, `ViewDetails`, `EditForm`.
- Adds ItemCard accessibility tests.

Lint unchanged at 101; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)