### PR TITLE
refactor: adopt js-yaml and papaparse for frontmatter and CSV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "dompurify": "^3.2.7",
         "fuse.js": "^7.1.0",
+        "js-yaml": "^4.2.0",
         "jszip": "^3.10.1",
         "lucide-react": "^0.544.0",
         "marked": "^16.4.0",
+        "papaparse": "^5.5.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
       },
@@ -1767,7 +1769,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -3195,10 +3196,19 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3981,6 +3991,12 @@
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "license": "(MIT AND Zlib)"
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
   "dependencies": {
     "dompurify": "^3.2.7",
     "fuse.js": "^7.1.0",
+    "js-yaml": "^4.2.0",
     "jszip": "^3.10.1",
     "lucide-react": "^0.544.0",
     "marked": "^16.4.0",
+    "papaparse": "^5.5.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },

--- a/src/utils/__tests__/markdownUtils.test.js
+++ b/src/utils/__tests__/markdownUtils.test.js
@@ -147,18 +147,32 @@ Notes.`;
       expect(result.metadata.status).toBe('reading');
     });
 
-    it('should handle frontmatter with quotes', () => {
+    it('should preserve quotes inside properly-escaped frontmatter', () => {
       const markdown = `---
-title: "The "Great" Gatsby"
+title: "The \\"Great\\" Gatsby"
 author: 'F. Scott Fitzgerald'
 ---
 
 Notes.`;
 
       const result = parseMarkdown(markdown);
-      
-      expect(result.metadata.title).toBe('The Great Gatsby');
+
+      expect(result.metadata.title).toBe('The "Great" Gatsby');
       expect(result.metadata.author).toBe('F. Scott Fitzgerald');
+    });
+
+    it('should preserve commas inside array values', () => {
+      const markdown = `---
+title: "Test Movie"
+type: "movie"
+actors: ["Smith, John", "Doe, Jane"]
+---
+
+Notes.`;
+
+      const result = parseMarkdown(markdown);
+
+      expect(result.metadata.actors).toEqual(['Smith, John', 'Doe, Jane']);
     });
   });
 
@@ -181,8 +195,8 @@ Notes.`;
       
       expect(markdown).toContain('---');
       expect(markdown).toContain('title: "Test Book"');
-      expect(markdown).toContain('type: book');
-      expect(markdown).toContain('status: read');
+      expect(markdown).toContain('type: "book"');
+      expect(markdown).toContain('status: "read"');
       expect(markdown).toContain('author: "Test Author"');
       expect(markdown).toContain('rating: 5');
       expect(markdown).toContain('year: 1925');
@@ -210,8 +224,8 @@ Notes.`;
       const markdown = generateMarkdown(item);
       
       expect(markdown).toContain('title: "Test Movie"');
-      expect(markdown).toContain('type: movie');
-      expect(markdown).toContain('status: watched');
+      expect(markdown).toContain('type: "movie"');
+      expect(markdown).toContain('status: "watched"');
       expect(markdown).toContain('director: "Test Director"');
       expect(markdown).toContain('actors: ["Actor One", "Actor Two"]');
       expect(markdown).toContain('rating: 4');
@@ -229,8 +243,8 @@ Notes.`;
       const markdown = generateMarkdown(item);
       
       expect(markdown).toContain('title: "Minimal Item"');
-      expect(markdown).toContain('type: book');
-      expect(markdown).toContain('status: read'); // Default status
+      expect(markdown).toContain('type: "book"');
+      expect(markdown).toContain('status: "read"'); // Default status
       expect(markdown).toContain('dateAdded: "2024-01-01"');
       expect(markdown).not.toContain('author:');
       expect(markdown).not.toContain('rating:');
@@ -244,8 +258,8 @@ Notes.`;
       };
 
       const markdown = generateMarkdown(item);
-      
-      expect(markdown).toContain('status: read');
+
+      expect(markdown).toContain('status: "read"');
     });
 
     it('should add default status for movie when missing', () => {
@@ -256,8 +270,8 @@ Notes.`;
       };
 
       const markdown = generateMarkdown(item);
-      
-      expect(markdown).toContain('status: watched');
+
+      expect(markdown).toContain('status: "watched"');
     });
 
     it('should handle empty tags array', () => {
@@ -321,8 +335,11 @@ Notes.`;
       };
 
       const markdown = generateMarkdown(item);
-      
-      expect(markdown).toContain('title: "Book: "A Story""');
+
+      // Quotes inside the value are escaped to keep the frontmatter valid YAML
+      expect(markdown).toContain('title: "Book: \\"A Story\\""');
+      // ...and it must round-trip back to the original title
+      expect(parseMarkdown(markdown).metadata.title).toBe('Book: "A Story"');
     });
   });
 
@@ -353,6 +370,27 @@ Notes.`;
       expect(parsed.metadata.tags).toEqual(original.tags);
       expect(parsed.body).toBe(original.review);
     });
+
+    it('should round-trip values containing quotes, commas, and colons', () => {
+      const original = {
+        title: 'Dune: Part "Two", Revisited',
+        type: 'movie',
+        status: 'watched',
+        director: 'Villeneuve, Denis',
+        actors: ['Chalamet, Timothée', 'Zendaya'],
+        tags: ['sci-fi', 'epic: space'],
+        dateAdded: '2024-03-01',
+        review: 'Great: a "must", really.',
+      };
+
+      const parsed = parseMarkdown(generateMarkdown(original));
+
+      expect(parsed.metadata.title).toBe(original.title);
+      expect(parsed.metadata.director).toBe(original.director);
+      expect(parsed.metadata.actors).toEqual(original.actors);
+      expect(parsed.metadata.tags).toEqual(original.tags);
+      expect(parsed.body).toBe(original.review);
+    });
   });
 
   describe('edge cases', () => {
@@ -365,9 +403,9 @@ Notes.`;
 
       const markdown = generateMarkdown(item);
       const parsed = parseMarkdown(markdown);
-      
-      // Quotes are stripped during parsing, but other special chars preserved
-      expect(parsed.metadata.title).toBe('Book: A Story / Path\\To\\File');
+
+      // Quotes and other special characters now round-trip losslessly
+      expect(parsed.metadata.title).toBe('Book: "A Story" / Path\\To\\File');
     });
 
     it('should handle very long titles', () => {

--- a/src/utils/csvUtils.js
+++ b/src/utils/csvUtils.js
@@ -1,3 +1,4 @@
+import Papa from 'papaparse';
 import { CSV_FORMATS, STATUS_TYPES, getDefaultStatus } from '../constants/index.js';
 import { toast } from '../services/toastService.js';
 
@@ -129,56 +130,18 @@ export { mapLetterboxdWatchedToStatus };
  * @returns {object} Object with headers array and rows array
  */
 export const parseCSV = (text) => {
-  // Basic RFC4180-compatible CSV parser (handles quoted fields)
-  const rows = [];
-  let cur = '';
-  let row = [];
-  let inQuotes = false;
-  
-  for (let i = 0; i < text.length; i++) {
-    const ch = text[i];
-    const nxt = text[i + 1];
+  // Delegate the RFC 4180 tokenizing (quotes, escaped quotes, embedded commas
+  // and newlines, BOM, CRLF) to papaparse. Headers and values are trimmed to
+  // preserve the historical behavior of this function.
+  const result = Papa.parse(text, {
+    header: true,
+    skipEmptyLines: 'greedy',
+    transformHeader: (h) => h.trim(),
+    transform: (v) => (typeof v === 'string' ? v.trim() : v)
+  });
 
-    if (ch === '"') {
-      if (inQuotes && nxt === '"') { // escaped quote
-        cur += '"';
-        i++; // skip next
-      } else {
-        inQuotes = !inQuotes;
-      }
-    } else if (ch === ',' && !inQuotes) {
-      row.push(cur);
-      cur = '';
-    } else if ((ch === '\n' || (ch === '\r' && nxt === '\n')) && !inQuotes) {
-      // handle CRLF or LF
-      if (ch === '\r' && nxt === '\n') i++;
-      row.push(cur);
-      rows.push(row);
-      row = [];
-      cur = '';
-    } else {
-      cur += ch;
-    }
-  }
-  
-  // push last
-  if (cur !== '' || row.length > 0) {
-    row.push(cur);
-    rows.push(row);
-  }
-
-  if (rows.length === 0) return { headers: [], rows: [] };
-
-  const headers = rows[0].map(h => h.trim());
-  const dataRows = rows.slice(1).map(r => {
-    const obj = {};
-    for (let i = 0; i < headers.length; i++) {
-      obj[headers[i]] = r[i] !== undefined ? r[i].trim() : '';
-    }
-    return obj;
-  }).filter(r => Object.values(r).some(v => v !== ''));
-
-  return { headers, rows: dataRows };
+  const headers = (result.meta.fields || []).map(h => h.trim());
+  return { headers, rows: result.data };
 };
 
 /**
@@ -297,24 +260,21 @@ export const exportCSV = (items = []) => {
       'dateRead', 'dateWatched', 'dateAdded', 'tags', 'coverUrl', 'review', 'filename'
     ];
 
-    const escape = (s) => {
-      if (s === null || s === undefined) return '""';
-      const str = String(Array.isArray(s) ? s.join(';') : s);
-      return '"' + str.replace(/"/g, '""') + '"';
+    const cell = (it, h) => {
+      switch (h) {
+        case 'actors': return (it.actors || []).join(';');
+        case 'tags': return (it.tags || []).join(';');
+        case 'filename': return it.filename || '';
+        case 'dateRead': return it.dateRead || '';
+        case 'dateWatched': return it.dateWatched || '';
+        default: return it[h] ?? '';
+      }
     };
 
-    const rows = items.map(it => headers.map(h => {
-      switch (h) {
-        case 'actors': return escape(it.actors || []);
-        case 'tags': return escape(it.tags || []);
-        case 'filename': return escape(it.filename || '');
-        case 'dateRead': return escape(it.dateRead || '');
-        case 'dateWatched': return escape(it.dateWatched || '');
-        default: return escape(it[h] ?? '');
-      }
-    }).join(',')).join('\n');
-
-    const csv = headers.join(',') + '\n' + rows;
+    const data = items.map(it => headers.map(h => cell(it, h)));
+    // quotes: true keeps every field quoted (parity with the previous export);
+    // papaparse handles escaping of embedded quotes/commas/newlines.
+    const csv = Papa.unparse({ fields: headers, data }, { quotes: true });
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const a = document.createElement('a');

--- a/src/utils/markdownUtils.js
+++ b/src/utils/markdownUtils.js
@@ -1,7 +1,23 @@
 // Markdown parsing and generation utilities
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
+import yaml from 'js-yaml';
 import { getDefaultStatus } from '../constants/index.js';
+
+const FRONTMATTER_REGEX = /^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/;
+
+/**
+ * Normalize a parsed YAML value to the string-based shape the rest of the app
+ * expects: scalars become strings, arrays become arrays of strings, and
+ * null/undefined become empty strings. js-yaml types numbers/booleans, but
+ * historically metadata values were always strings, so we preserve that.
+ */
+const normalizeMetaValue = (value) => {
+  if (Array.isArray(value)) return value.map(v => (v == null ? '' : String(v)));
+  if (value == null) return '';
+  if (typeof value === 'object') return value; // unexpected, but don't lose it
+  return String(value);
+};
 
 /**
  * Parse markdown content with YAML frontmatter
@@ -9,36 +25,33 @@ import { getDefaultStatus } from '../constants/index.js';
  * @returns {object} Object with metadata and body
  */
 export const parseMarkdown = (content) => {
-  const frontmatterRegex = /^---\s*\n([\s\S]*?)\n---\s*\n([\s\S]*)$/;
-  const match = content.match(frontmatterRegex);
-  
+  const match = content.match(FRONTMATTER_REGEX);
+
   if (!match) return { metadata: {}, body: content };
-  
+
+  const body = match[2].trim();
+
+  let parsed;
+  try {
+    parsed = yaml.load(match[1]);
+  } catch {
+    // Malformed frontmatter — degrade gracefully rather than throw.
+    return { metadata: {}, body };
+  }
+
   const metadata = {};
-  const yamlLines = match[1].split('\n').filter(line => line.trim() !== '');
-  
-  yamlLines.forEach(line => {
-    const colonIndex = line.indexOf(':');
-    if (colonIndex > -1) {
-      const key = line.substring(0, colonIndex).trim();
-      let value = line.substring(colonIndex + 1).trim();
-      
-      if (value.startsWith('[') && value.endsWith(']')) {
-        value = value.slice(1, -1).split(',').map(v => v.trim().replace(/['"]/g, ''));
-      } else {
-        value = value.replace(/['"]/g, '');
-      }
-      
-      metadata[key] = value;
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    for (const [key, value] of Object.entries(parsed)) {
+      metadata[key] = normalizeMetaValue(value);
     }
-  });
+  }
 
   // Add default status for backward compatibility if not present
   if (!metadata.status && metadata.type) {
     metadata.status = getDefaultStatus(metadata.type);
   }
-  
-  return { metadata, body: match[2].trim() };
+
+  return { metadata, body };
 };
 
 /**
@@ -47,29 +60,37 @@ export const parseMarkdown = (content) => {
  * @returns {string} Markdown content with frontmatter
  */
 export const generateMarkdown = (item) => {
-  let yaml = '---\n';
-  yaml += `title: "${item.title}"\n`;
-  yaml += `type: ${item.type}\n`;
-  
-  // Add status field with default if not present
-  const status = item.status || getDefaultStatus(item.type);
-  yaml += `status: ${status}\n`;
-  
-  if (item.author) yaml += `author: "${item.author}"\n`;
-  if (item.director) yaml += `director: "${item.director}"\n`;
-  if (item.actors) yaml += `actors: [${item.actors.map(a => `"${a}"`).join(', ')}]\n`;
-  if (item.isbn) yaml += `isbn: "${item.isbn}"\n`;
-  if (item.year) yaml += `year: ${item.year}\n`;
-  if (item.rating) yaml += `rating: ${item.rating}\n`;
-  if (item.tags && item.tags.length > 0) yaml += `tags: [${item.tags.map(t => `"${t}"`).join(', ')}]\n`;
-  if (item.coverUrl) yaml += `coverUrl: "${item.coverUrl}"\n`;
-  
-  if (item.dateRead) yaml += `dateRead: "${item.dateRead}"\n`;
-  if (item.dateWatched) yaml += `dateWatched: "${item.dateWatched}"\n`;
-  yaml += `dateAdded: "${item.dateAdded}"\n`;
-  yaml += '---\n\n';
-  
-  return yaml + (item.review || '');
+  // Build the frontmatter object in a stable field order, including only the
+  // fields that are present (matching the historical output).
+  const frontmatter = {
+    title: item.title,
+    type: item.type,
+    status: item.status || getDefaultStatus(item.type)
+  };
+
+  if (item.author) frontmatter.author = item.author;
+  if (item.director) frontmatter.director = item.director;
+  if (item.actors) frontmatter.actors = item.actors;
+  if (item.isbn) frontmatter.isbn = item.isbn;
+  if (item.year) frontmatter.year = item.year;
+  if (item.rating) frontmatter.rating = item.rating;
+  if (item.tags && item.tags.length > 0) frontmatter.tags = item.tags;
+  if (item.coverUrl) frontmatter.coverUrl = item.coverUrl;
+  if (item.dateRead) frontmatter.dateRead = item.dateRead;
+  if (item.dateWatched) frontmatter.dateWatched = item.dateWatched;
+  frontmatter.dateAdded = item.dateAdded;
+
+  // forceQuotes + double quotes -> string values are safely escaped;
+  // flowLevel: 1 keeps arrays inline (tags: ["a", "b"]); lineWidth: -1
+  // prevents js-yaml from wrapping long values across lines.
+  const dumped = yaml.dump(frontmatter, {
+    flowLevel: 1,
+    forceQuotes: true,
+    quotingType: '"',
+    lineWidth: -1
+  });
+
+  return `---\n${dumped}---\n\n${item.review || ''}`;
 };
 
 /**


### PR DESCRIPTION
Fourth of six hardening PRs. **Stacked on #74** (`feat/accessibility`).

Replace the hand-rolled YAML frontmatter and CSV parsers with libraries, fixing real round-trip bugs:

- **markdownUtils:** parse with `js-yaml` (graceful fallback on malformed input), generate with `js-yaml` dump (`forceQuotes` + flow arrays). Quotes, commas, and colons inside titles/authors/actors/tags now round-trip losslessly; array values are no longer split on embedded commas. Parsed scalars are coerced to strings to preserve the existing metadata contract.
- **csvUtils:** parse with `papaparse` (handles BOM, CRLF, escaped quotes, embedded commas/newlines), export with `Papa.unparse`. Goodreads/Letterboxd row mappers unchanged.
- Updated `markdownUtils` tests to assert correct (non-buggy) behavior; added round-trip cases for quotes/commas/colons.

All 45 existing `data/*.md` files parse cleanly. Adds `js-yaml` + `papaparse` deps. Lint unchanged at 101; build clean.

> Note: one integration test (`itemManagement`) can flake under full-suite load (passes in isolation and on baseline; js-yaml/papaparse are ~0.01ms/call). The isolation fix in the final PR of the series addresses it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)