### PR TITLE
refactor: kill storage-indicator polling, extract parseTagList

### DIFF
--- a/src/MediaTracker.jsx
+++ b/src/MediaTracker.jsx
@@ -540,20 +540,9 @@ const MediaTracker = () => {
     }
   };
 
-  // Track storage indicator state
+  // Track storage indicator state (updated reactively via StorageIndicator's
+  // onOpenChange callback — see the <StorageIndicator> render below).
   const [storageIndicatorOpen, setStorageIndicatorOpen] = useState(false);
-
-  // Update storage indicator state when it changes
-  useEffect(() => {
-    const interval = setInterval(() => {
-      if (storageIndicatorRef.current) {
-        const isOpen = storageIndicatorRef.current.isOpen();
-        setStorageIndicatorOpen(isOpen);
-      }
-    }, 100); // Check every 100ms
-
-    return () => clearInterval(interval);
-  }, []);
 
   // Cleanup export submenu timeout on unmount
   useEffect(() => {
@@ -1683,6 +1672,7 @@ const MediaTracker = () => {
             storageAdapter={storageAdapter}
             storageInfo={storageInfo}
             onSwitchStorage={handleDisconnectStorage}
+            onOpenChange={setStorageIndicatorOpen}
             onRefresh={() => loadItems()}
           />
         )}

--- a/src/components/StorageIndicator.jsx
+++ b/src/components/StorageIndicator.jsx
@@ -5,7 +5,7 @@ import { Cloud, FolderOpen, Folder, User, Wifi, WifiOff, ArrowLeft } from 'lucid
  * Compact Storage Indicator Component
  * Shows storage status in bottom right, expandable on click
  */
-const StorageIndicator = forwardRef(({ storageAdapter, storageInfo, onSwitchStorage }, ref) => {
+const StorageIndicator = forwardRef(({ storageAdapter, storageInfo, onSwitchStorage, onOpenChange }, ref) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
   // Expose methods to parent component
@@ -15,6 +15,12 @@ const StorageIndicator = forwardRef(({ storageAdapter, storageInfo, onSwitchStor
     toggleModal: () => setIsExpanded(prev => !prev),
     isOpen: () => isExpanded
   }));
+
+  // Notify the parent whenever the open state changes, so it can react without
+  // polling the imperative handle.
+  useEffect(() => {
+    onOpenChange?.(isExpanded);
+  }, [isExpanded, onOpenChange]);
 
   // Handle keyboard shortcuts when modal is open
   useEffect(() => {

--- a/src/components/__tests__/StorageIndicator.test.jsx
+++ b/src/components/__tests__/StorageIndicator.test.jsx
@@ -120,6 +120,24 @@ describe('StorageIndicator', () => {
       expect(screen.getByText('Connected')).toBeInTheDocument();
     });
 
+    it('should report open state changes via onOpenChange', async () => {
+      const onOpenChange = vi.fn();
+      render(
+        <StorageIndicator
+          storageAdapter={mockStorageAdapter}
+          storageInfo="/path/to/folder"
+          onSwitchStorage={onSwitchStorage}
+          onOpenChange={onOpenChange}
+        />
+      );
+
+      // Called with false on mount
+      expect(onOpenChange).toHaveBeenLastCalledWith(false);
+
+      await user.click(screen.getByTitle('Storage: Local Files'));
+      expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    });
+
     it('should close panel when backdrop is clicked', async () => {
       render(
         <StorageIndicator 

--- a/src/components/modals/BatchEditModal.jsx
+++ b/src/components/modals/BatchEditModal.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { X } from 'lucide-react';
 import { STATUS_TYPES, STATUS_LABELS } from '../../constants/index.js';
 import { toast } from '../../services/toastService.js';
+import { parseTagList } from '../../utils/commonUtils.js';
 
 /**
  * Modal for batch editing multiple selected items
@@ -40,13 +41,12 @@ const BatchEditModal = ({ onClose, onApply, selectedItems = [], isProcessing = f
     if (applyAddTags && addTagsStr) {
       out.after.tags = Array.from(new Set([
         ...(out.after.tags || []),
-        ...addTagsStr.split(',').map(s => s.trim()).filter(Boolean)
+        ...parseTagList(addTagsStr)
       ]));
     }
     if (applyRemoveTags && removeTagsStr) {
-      out.after.tags = (out.after.tags || []).filter(t =>
-        !removeTagsStr.split(',').map(s => s.trim()).filter(Boolean).includes(t)
-      );
+      const toRemove = parseTagList(removeTagsStr);
+      out.after.tags = (out.after.tags || []).filter(t => !toRemove.includes(t));
     }
     if (applyDateRead && dateRead) out.after.dateRead = dateRead;
     if (applyDateWatched && dateWatched) out.after.dateWatched = dateWatched;
@@ -61,8 +61,8 @@ const BatchEditModal = ({ onClose, onApply, selectedItems = [], isProcessing = f
     if (applyDirector) changes.director = director;
     if (applyYear) changes.year = year;
     if (applyRating) changes.rating = rating;
-    if (applyAddTags) changes.addTags = addTagsStr ? addTagsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
-    if (applyRemoveTags) changes.removeTags = removeTagsStr ? removeTagsStr.split(',').map(s => s.trim()).filter(Boolean) : [];
+    if (applyAddTags) changes.addTags = parseTagList(addTagsStr);
+    if (applyRemoveTags) changes.removeTags = parseTagList(removeTagsStr);
     if (applyDateRead) changes.dateRead = dateRead;
     if (applyDateWatched) changes.dateWatched = dateWatched;
     if (applyStatus) changes.status = status;

--- a/src/utils/__tests__/commonUtils.test.js
+++ b/src/utils/__tests__/commonUtils.test.js
@@ -1,7 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { isTyping, isMobileScreen, getTodayDate, autoUpdateDateOnStatusChange } from '../commonUtils.js';
+import { isTyping, isMobileScreen, getTodayDate, autoUpdateDateOnStatusChange, parseTagList } from '../commonUtils.js';
 
 describe('commonUtils', () => {
+  describe('parseTagList', () => {
+    it('should split, trim, and drop empty tags', () => {
+      expect(parseTagList(' fiction , classic ,, sci-fi ')).toEqual(['fiction', 'classic', 'sci-fi']);
+    });
+
+    it('should return an empty array for empty or nullish input', () => {
+      expect(parseTagList('')).toEqual([]);
+      expect(parseTagList(null)).toEqual([]);
+      expect(parseTagList(undefined)).toEqual([]);
+    });
+  });
+
   describe('isTyping', () => {
     it('should return true when user is typing in an input', () => {
       // Mock document.activeElement

--- a/src/utils/commonUtils.js
+++ b/src/utils/commonUtils.js
@@ -12,6 +12,15 @@ export const isTyping = () => {
 };
 
 /**
+ * Parse a comma-separated tag string into a clean array of non-empty,
+ * trimmed tags.
+ * @param {string} value - Comma-separated tag string
+ * @returns {string[]} Array of trimmed, non-empty tags
+ */
+export const parseTagList = (value) =>
+  (value || '').split(',').map(s => s.trim()).filter(Boolean);
+
+/**
  * Generate a filename for an item
  * @param {string} title - Item title
  * @returns {string} Generated filename


### PR DESCRIPTION
Fifth of six hardening PRs. **Stacked on #75** (`feat/parser-libraries`).

- **Remove the 100ms poll:** the header polled `StorageIndicator.isOpen()` every 100ms (10 setState/sec for the app's lifetime) just to mirror its expanded state into `hasOpenModal`. `StorageIndicator` now reports changes via an `onOpenChange` callback fired from an effect, and `MediaTracker` drops the `setInterval`.
- **Extract `parseTagList`** into `commonUtils` (null-safe) and reuse it for the four repeated `split(',').map(trim).filter(Boolean)` sites in `BatchEditModal`.
- Adds tests for both.

**Scope note:** the broader decomposition (Theme/Selection contexts, splitting the large modals, extracting orchestration hooks) was deliberately deferred — `MediaTracker.jsx` is excluded from coverage and CLAUDE.md says not to refactor it without integration tests first, and a ThemeContext would break the 46 prop-based ItemCard tests. Recommend a dedicated follow-up that adds those integration tests first.

Lint unchanged at 101; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)